### PR TITLE
added-comment-with-example-of-how-to-add-path-for-image

### DIFF
--- a/Dashboard/dash_app/template/index.html
+++ b/Dashboard/dash_app/template/index.html
@@ -3,4 +3,4 @@
 
 <img src="{{c}}" height ="400" width="300"alt=" ">
 
-
+<!--  <img src="{% static 'assets/img/3.jpg' %}" height ="400" width="300"alt=" ">-->


### PR DESCRIPTION
In my images the actual path was C:\rujul-projects\capstoneproject\Dashboard\dash_app\static\assets\img\3.jpg
But i setup a static variable with the path till static\

and then the rest you have to add in above syntax